### PR TITLE
graphql queries executed in goroutines.

### DIFF
--- a/handle/test/graphql_test.go
+++ b/handle/test/graphql_test.go
@@ -287,7 +287,6 @@ func TestGraphQL(t *testing.T) {
 			r.SetBasicAuth("vehicles_user", "12345678")
 			server.ServeHTTP(rec, r)
 			Expect(rec.Body.String()).To(MatchJSON(`{
-              "data": null,
               "errors": [{
                 "message": "_read permission for this path needed."
               }]
@@ -301,7 +300,6 @@ func TestGraphQL(t *testing.T) {
 			r.SetBasicAuth("boat_user", "12345678")
 			server.ServeHTTP(rec, r)
 			Expect(rec.Body.String()).To(MatchJSON(`{
-              "data": null,
               "errors": [{
                 "message": "_read permission for this path needed."
               }]
@@ -317,7 +315,6 @@ func TestGraphQL(t *testing.T) {
 			r.SetBasicAuth("boat_user", "12345678")
 			server.ServeHTTP(rec, r)
 			Expect(rec.Body.String()).To(MatchJSON(`{
-              "data": null,
               "errors": [{
                 "message": "_read permission for this path needed."
               }]


### PR DESCRIPTION
ConcurrentMap from https://github.com/streamrail/concurrent-map being used.

stupid benchmarks show that we can do now
BenchmarkGraphQLQuery       2000            515342 ns/op

while before they averaged
BenchmarkGraphQLQuery      10000            124391 ns/op

so, is it good? I don't know.

---

also, this commit removes "data" keys from graphql error responses, as errors
can only happen before the response starts being constructed and the spec says
that in this case "data" should not be present.

after we start building the response some response is always returned, even
if it is a nested tree full of null values.
